### PR TITLE
[refactor] 더미 데이터 수정 및 페스티벌 당일 시간표 로직 수정

### DIFF
--- a/Mufe/Mufe/Presentation/Model/Dummy/DummyFestivalData.swift
+++ b/Mufe/Mufe/Presentation/Model/Dummy/DummyFestivalData.swift
@@ -252,8 +252,8 @@ struct DummyFestivalData {
         Festival(
             imageName: "countdown_fantasy",
             name: "COUNTDOWN FANTASY 2025-2026",
-            startDate: "2025.12.15",
-            endDate: "2025.12.16",
+            startDate: "2025.12.19",
+            endDate: "2025.12.20",
             location: "일산 KINTEX",
             artistSchedule: [
                 "1일차": [
@@ -307,8 +307,8 @@ struct DummyFestivalData {
                 ]
             ],
             days: [
-                FestivalDay(dayOfWeek: "월", date: "2025.12.15"),
-                FestivalDay(dayOfWeek: "화", date: "2025.12.16")
+                FestivalDay(dayOfWeek: "금", date: "2025.12.19"),
+                FestivalDay(dayOfWeek: "토", date: "2025.12.20")
             ]
         ),
         

--- a/Mufe/Mufe/Presentation/View/Home/DdayFestivalView.swift
+++ b/Mufe/Mufe/Presentation/View/Home/DdayFestivalView.swift
@@ -71,7 +71,16 @@ final class DdayFestivalView: UIView {
     
     func updateFestivalTimes(_ times: [SavedTimetable]) {
         DispatchQueue.main.async {
-            self.timetables = times
+            let sortedTimes = times.sorted { (first, second) -> Bool in
+                func adjustedHour(_ timeString: String) -> Int {
+                    let hour = Int(timeString.prefix(2)) ?? 0
+                    return hour < 6 ? hour + 24 : hour
+                }
+                
+                return adjustedHour(first.startTime) < adjustedHour(second.startTime)
+            }
+            
+            self.timetables = sortedTimes
             self.festivalCollectionView.reloadData()
         }
     }


### PR DESCRIPTION
## 📟 연결된 이슈
closed #34 

## 👷 작업한 내용
- 시연당일로 더미 데이터 수정하였습니다.
- 페스티벌 당일 시간표 로직을 오전 6시 이후 스케줄부터 정렬되도록 수정하였습니다.

## 📸 스크린샷
<img src = "https://github.com/user-attachments/assets/24025cf8-4150-49e0-aebb-229a3f7c0a2c" width ="250">
